### PR TITLE
!Array#empty? vs Array#any?

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,23 @@ Comparison:
           Array#last:  7639254.5 i/s - 1.12x slower
 ```
 
+##### `!Array#empty?` vs `Array#any?` [code](code/array/array-any-vs-not-empty.rb)
+
+```
+$ ruby -v code/array/array-any-vs-not-empty.rb
+ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-linux]
+
+Calculating -------------------------------------
+       !Array#empty?   143.635k i/100ms
+          Array#any?   134.023k i/100ms
+-------------------------------------------------
+       !Array#empty?      7.107M (± 1.9%) i/s -     35.621M
+          Array#any?      6.760M (± 1.9%) i/s -     33.908M
+
+Comparison:
+       !Array#empty?:  7107124.9 i/s
+          Array#any?:  6760372.4 i/s - 1.05x slower
+```
 
 ### Enumerable
 

--- a/code/array/array-any-vs-not-empty.rb
+++ b/code/array/array-any-vs-not-empty.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+ARRAY = [*1..1000]
+
+def fast
+  !ARRAY.empty?
+end
+
+def slow
+  ARRAY.any?
+end
+
+Benchmark.ips do |x|
+  x.report('!Array#empty?') { fast }
+  x.report('Array#any?') { slow }
+  x.compare!
+end


### PR DESCRIPTION
Difference for 2.1.4 is much bigger.

```
ruby 2.1.4p265 (2014-10-27 revision 48166) [x86_64-linux]

Calculating -------------------------------------
       !array.empty?   126.879k i/100ms
          array.any?    89.568k i/100ms
-------------------------------------------------
       !array.empty?      6.329M (± 3.6%) i/s -     31.593M
          array.any?      2.432M (± 1.5%) i/s -     12.181M

Comparison:
       !array.empty?:  6329175.1 i/s
          array.any?:  2432104.3 i/s - 2.60x slower
```
