### PR TITLE
Add val.between?(start, end) to range comparisons

### DIFF
--- a/code/range/cover-vs-include.rb
+++ b/code/range/cover-vs-include.rb
@@ -10,6 +10,7 @@ Benchmark.ips do |x|
   x.report('range#include?') { (BEGIN_OF_JULY..END_OF_JULY).include? DAY_IN_JULY }
   x.report('range#member?') { (BEGIN_OF_JULY..END_OF_JULY).member? DAY_IN_JULY }
   x.report('plain compare') { BEGIN_OF_JULY < DAY_IN_JULY && DAY_IN_JULY < END_OF_JULY }
-
+  x.report('value.between?') { DAY_IN_JULY.between?(BEGIN_OF_JULY, END_OF_JULY) }
+  
   x.compare!
 end


### PR DESCRIPTION
add value.between?(start, end) to range compares. 
It tested fastest against others on MRI 2.2.3, and tied for best on JRuby 9.0.4.0
