### PR TITLE
Add benchmark for Array#new vs. Fixnum#times + map

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,22 @@ Comparison:
         Array#insert:        0.2 i/s - 262.56x slower
 ```
 
+##### `Array#new` vs `Fixnum#times + map` [code](code/array/array-new-vs-fixnum-times-map.rb)
+
+```
+ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
+Calculating -------------------------------------
+           Array#new    63.875k i/100ms
+  Fixnum#times + map    48.010k i/100ms
+-------------------------------------------------
+           Array#new      1.070M (± 2.2%) i/s -      5.365M
+  Fixnum#times + map    678.097k (± 2.7%) i/s -      3.409M
+
+Comparison:
+           Array#new:  1069837.0 i/s
+  Fixnum#times + map:   678097.4 i/s - 1.58x slower
+```
+
 ### Enumerable
 
 ##### `Enumerable#each + push` vs `Enumerable#map` [code](code/enumerable/each-push-vs-map.rb)

--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ Comparison:
 
 ##### `Array#new` vs `Fixnum#times + map` [code](code/array/array-new-vs-fixnum-times-map.rb)
 
+Typical slowdown is 40-60% depending on the size of the array. See the corresponding
+[pull request](https://github.com/JuanitoFatas/fast-ruby/pull/91/) for performance characteristics.
+
 ```
 ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
 Calculating -------------------------------------

--- a/code/array/array-new-vs-fixnum-times-map.rb
+++ b/code/array/array-new-vs-fixnum-times-map.rb
@@ -1,0 +1,17 @@
+require "benchmark/ips"
+
+ELEMENTS = 9
+
+def fast
+  Array.new(ELEMENTS) { |i| i }
+end
+
+def slow
+  ELEMENTS.times.map { |i| i }
+end
+
+Benchmark.ips do |x|
+  x.report("Array#new") { fast }
+  x.report("Fixnum#times + map") { slow }
+  x.compare!
+end


### PR DESCRIPTION
When you need to map the result of a block invoked a fixed amount of times, you have an option between:

```
Array.new(n) { ... }
```

and:

```
n.times.map { ... }
```

The latter one is about 60% slower for `n = 10`, which goes down to around 40% for `n > 1_000.`

_Note: logarithmic scale!_

<img width="562" alt="screen shot 2016-01-11 at 20 23 40" src="https://cloud.githubusercontent.com/assets/5259935/12254343/49cefa02-b922-11e5-9895-c88a835a435f.png">
