### PR TITLE
Remove overhead of surrounding block from length-vs-size-vs-count benchmark

### DIFF
--- a/code/array/length-vs-size-vs-count.rb
+++ b/code/array/length-vs-size-vs-count.rb
@@ -1,10 +1,10 @@
 require 'benchmark/ips'
 
-ARRAY = [*1..100]
+$array = [*1..100]
 
 Benchmark.ips do |x|
-  x.report("Array#length") { ARRAY.length }
-  x.report("Array#size") { ARRAY.size }
-  x.report("Array#count") { ARRAY.count }
+  x.report("Array#length", "$array.length;" * 1_000)
+  x.report("Array#size",   "$array.size;"   * 1_000)
+  x.report("Array#count",  "$array.count;"  * 1_000)
   x.compare!
 end


### PR DESCRIPTION
See #96 for detailed explanation

Before:

```
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
Calculating -------------------------------------
        Array#length   135.292k i/100ms
          Array#size   137.775k i/100ms
         Array#count   132.586k i/100ms
-------------------------------------------------
        Array#length      9.906M (± 7.6%) i/s -     49.246M
          Array#size     10.038M (± 6.0%) i/s -     50.012M
         Array#count      8.399M (± 6.0%) i/s -     41.897M

Comparison:
          Array#size: 10038186.0 i/s
        Array#length:  9905809.3 i/s - 1.01x slower
         Array#count:  8399076.6 i/s - 1.20x slower
```

After:

```
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
Calculating -------------------------------------
        Array#length    10.290k i/100ms
          Array#size    10.301k i/100ms
         Array#count     3.649k i/100ms
-------------------------------------------------
        Array#length    111.847k (± 2.0%) i/s -    565.950k
          Array#size    112.374k (± 2.0%) i/s -    566.555k
         Array#count     37.865k (± 2.1%) i/s -    189.748k

Comparison:
          Array#size:   112373.6 i/s
        Array#length:   111847.4 i/s - 1.00x slower
         Array#count:    37865.1 i/s - 2.97x slower
```
