### PR TITLE
compare gsub vs tr vs delete to remove character from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,6 +1329,24 @@ Comparison:
          String#gsub:   516604.2 i/s - 3.60x slower
 ```
 
+##### `String#gsub` vs `String#tr` vs `String#del` [code](code/string/gsub-vs-tr-vs-del.rb)
+
+```
+ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-linux]
+
+Calculating -------------------------------------
+         String#gsub      1.342M (± 1.3%) i/s -      6.816M in   5.079675s
+           String#tr      2.627M (± 1.0%) i/s -     13.387M in   5.096083s
+       String#delete      2.924M (± 0.7%) i/s -     14.889M in   5.093070s
+ String#delete const      3.136M (± 2.6%) i/s -     15.866M in   5.064043s
+
+Comparison:
+ String#delete const:  3135559.1 i/s
+       String#delete:  2923531.8 i/s - 1.07x  slower
+           String#tr:  2627150.5 i/s - 1.19x  slower
+         String#gsub:  1342013.4 i/s - 2.34x  slower
+```
+
 ##### `Mutable` vs `Immutable` [code](code/string/mutable_vs_immutable_strings.rb)
 
 ```

--- a/code/string/gsub-vs-tr-vs-delete.rb
+++ b/code/string/gsub-vs-tr-vs-delete.rb
@@ -1,0 +1,28 @@
+require 'benchmark/ips'
+
+WORDS = 'writing fast ruby'
+SPACE = ' '
+
+def use_gsub
+  WORDS.gsub(' ', '')
+end
+
+def use_tr
+  WORDS.tr(' ', '')
+end
+
+def use_delete
+  WORDS.delete(' ')
+end
+
+def use_delete_const
+  WORDS.delete(SPACE)
+end
+
+Benchmark.ips do |x|
+  x.report('String#gsub') { use_gsub }
+  x.report('String#tr') { use_tr }
+  x.report('String#delete') { use_delete }
+  x.report('String#delete const') { use_delete_const }
+  x.compare!
+end


### PR DESCRIPTION
This benchmark proves that delete is faster than tr and both are considerably faster than gsub when removing a character from a string.