### PR TITLE
Compare Hash#select#values vs Hash#values#select vs Hash#values#compact

### DIFF
--- a/code/hash/select-vs-values.compact.rb
+++ b/code/hash/select-vs-values.compact.rb
@@ -1,0 +1,24 @@
+require 'benchmark/ips'
+
+ARRAY = Array.new(1000) { Random.rand }
+VALUES = ARRAY.map { |v| v < 0.5 }
+HASH = Hash[ARRAY.zip(VALUES)]
+
+def fastest
+  HASH.values.compact
+end
+
+def fast
+  HASH.values.select { |v| v }
+end
+
+def slow
+  HASH.select { |_k, v| v }.values
+end
+
+Benchmark.ips do |x|
+  x.report('Hash#select#values') { slow }
+  x.report("Hash#values.select") { fast }
+  x.report("Hash#values#compact") { fastest }
+  x.compare!
+end


### PR DESCRIPTION
This benchmark proves that get not nil values from hash is fastest with Hash#values#compact