### PR TITLE
Note about block argument vs yield since 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,8 @@ Comparison:
           block.call:   842581.2 i/s - 4.54x slower
 ```
 
+Note, that since 2.5 `block argument` and `yield` have same-ish speed.
+See [[Feature #14045]](https://bugs.ruby-lang.org/issues/14045)
 
 ### String
 


### PR DESCRIPTION
I get this results now:

```
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
Warming up --------------------------------------
          block.call    97.516k i/100ms
       block + yield   222.753k i/100ms
      block argument   213.670k i/100ms
               yield   214.345k i/100ms
Calculating -------------------------------------
          block.call      1.385M (± 4.6%) i/s -      6.924M in   5.010670s
       block + yield      6.053M (± 3.8%) i/s -     30.294M in   5.012828s
      block argument      7.208M (± 4.8%) i/s -     36.110M in   5.022268s
               yield      7.013M (± 4.2%) i/s -     35.153M in   5.022215s

Comparison:
      block argument:  7208248.5 i/s
               yield:  7012638.0 i/s - same-ish: difference falls within error
       block + yield:  6052632.0 i/s - 1.19x  slower
          block.call:  1385028.4 i/s - 5.20x  slower
```
