### PR TITLE
Add Array#to_h comparison with several other implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,30 @@ Comparison:
         Array#insert:        0.2 i/s - 262.56x slower
 ```
 
+#### `Array#each` vs `Array#to_h` vs `Hash::[]` plus `Array#map` vs `Array#map` plus `Array#to_h` vs `Enumerable#each_with_object` vs `Object#tap` plus `Array#each`
+
+The option to process a block when given was added to `to_h` in Ruby 2.6.
+
+```
+$ ruby -v code/array/toh-vs-each-vs-Hash\[\]-map-vs-map-toh-vs-each-with-object-vs-tap-each.rb
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin18]
+Calculating -------------------------------------
+                 Array#to_h   478.397k (± 4.0%) i/s -      2.410M in   5.046234s
+                 Array#each   526.423k (± 3.3%) i/s -      2.673M in   5.083944s
+    Hash::[] plus Array#map   410.417k (± 4.6%) i/s -      2.053M in   5.013472s
+  Array#map plus Array#to_h   412.382k (± 4.9%) i/s -      2.075M in   5.044099s
+Enumerable#each_with_object   459.695k (± 3.3%) i/s -      2.337M in   5.090124s
+ Object#tap plus Array#each   455.039k (± 3.7%) i/s -      2.290M in   5.040278s
+
+Comparison:
+                 Array#each:  526422.7 i/s
+                 Array#to_h:  478397.0 i/s - 1.10x  (± 0.00) slower
+Enumerable#each_with_object:  459695.4 i/s - 1.15x  (± 0.00) slower
+ Object#tap plus Array#each:  455039.5 i/s - 1.16x  (± 0.00) slower
+  Array#map plus Array#to_h:  412381.8 i/s - 1.28x  (± 0.00) slower
+    Hash::[] plus Array#map:  410417.2 i/s - 1.28x  (± 0.00) slower
+```
+
 ### Enumerable
 
 ##### `Enumerable#each + push` vs `Enumerable#map` [code](code/enumerable/each-push-vs-map.rb)

--- a/code/array/toh-vs-each-vs-Hash[]-map-vs-map-toh-vs-each-with-object-vs-tap-each.rb
+++ b/code/array/toh-vs-each-vs-Hash[]-map-vs-map-toh-vs-each-with-object-vs-tap-each.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+
+class People
+  def initialize(first_name, last_name)
+    @first_name = first_name
+    @last_name = last_name
+  end
+
+  def login
+    "#{first_name.downcase}-#{last_name.downcase}"
+  end
+
+  private
+
+  attr_reader :first_name, :last_name
+end
+
+PEOPLE = [People.new('John', 'Doe'), People.new('Lola', 'Lanos')].freeze
+
+def fast
+  hash = {}
+  PEOPLE.dup.each { |person| hash[person.login] = person }
+  hash
+end
+
+def slow_to_h
+  PEOPLE.dup.to_h { |person| [person.login, person] }
+end
+
+def slow_hash_new_map
+  Hash[PEOPLE.dup.map { |person, hash| [person.login, person] }]
+end
+
+def slow_map_to_h
+  PEOPLE.dup.map { |person, hash| [person.login, person] }.to_h
+end
+
+def slow_each_with_object
+  PEOPLE.dup.each_with_object({}) { |person, hash| hash[person.login] = person }
+end
+
+def slow_tap
+  {}.tap { |new_hash| PEOPLE.dup.each { |person, foo| new_hash[person.login] = person } }
+end
+
+Benchmark.ips do |x|
+  x.report("Array#each")                  { fast }
+  x.report("Array#to_h")                  { slow_to_h }
+  x.report("Hash::[] plus Array#map")     { slow_hash_new_map }
+  x.report("Array#map plus Array#to_h")   { slow_map_to_h }
+  x.report("Enumerable#each_with_object") { slow_each_with_object }
+  x.report("Object#tap plus Array#each")  { slow_tap }
+  x.compare!
+end


### PR DESCRIPTION
As Ruby 2.6 added support for executing a block when passed to `to_h` I think we can add it with the other implementations to achieve the same output.

Ruby on Rails also has a shorter way [`Enumerable#index_by`](https://api.rubyonrails.org/classes/Enumerable.html#method-i-index_by) which I didn't want to include, but it's worth mentioning for those working with the framework.