### PR TITLE
Hash#has_key? vs Set#include?

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,27 @@ Array#each_w/_object:  1352851.8 i/s - 1.88x  slower
 Hash#select-include :   760944.2 i/s - 3.34x  slower
 ```
 
+##### `Hash#has_key?` vs `Set#include?` [code](code/hash/set-vs-hash-include.rb)
+
+When checking for the presence of an element in an associative set.
+
+> Aliases of `Hash#has_key?`: `Hash#include?`, `Hash#member?`, `Hash#key?`.
+>
+> Aliases of `Set#include?`: `Set#member?`, `Set#===`.
+
+```
+ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin19]
+Warming up --------------------------------------
+       Hash#has_key?   849.008k i/100ms
+        Set#include?   744.386k i/100ms
+Calculating -------------------------------------
+       Hash#has_key?      8.550M (± 1.4%) i/s -     43.299M in   5.065260s
+        Set#include?      7.448M (± 1.5%) i/s -     37.964M in   5.098234s
+
+Comparison:
+       Hash#has_key?:  8550055.4 i/s
+        Set#include?:  7448196.8 i/s - 1.15x  (± 0.00) slower
+```
 
 ### Proc & Block
 

--- a/code/hash/set-vs-hash-include.rb
+++ b/code/hash/set-vs-hash-include.rb
@@ -1,0 +1,19 @@
+require 'benchmark/ips'
+require 'set'
+
+HASH = Hash[*('a'..'z').map { |key| [key, true] }]
+SET = Set[*('a'..'z').to_a]
+
+def fast
+  HASH.has_key?('n')
+end
+
+def slow
+  SET.include?('n')
+end
+
+Benchmark.ips do |x|
+  x.report('Hash#has_key?') { fast }
+  x.report('Set#include?') { slow }
+  x.compare!
+end


### PR DESCRIPTION
When selecting a data structure to store a set of unique elements, in which a common operation will be to check if an element is part of that data structure, the a [`Set`](https://ruby-doc.org/stdlib-3.0.1/libdoc/set/rdoc/Set.html) comes to mind as the ideal, minimal choice.

One downside of `Set` is that it's slower than a `Hash` when checking for present of an element, even though `Set`'s implementation is [backed by a `Hash`](https://github.com/ruby/ruby/blob/929cc615a749f467809a865a3d40adcc0b58c667/lib/set.rb#L401-L403).

This PR documents the difference in performance profile between `Hash#has_key?` and `Set#include?` to help users that need to check for an association in performance critical paths.