### PR TITLE
Compare one n-element hash#merge! vs n assignments with []=

### DIFF
--- a/code/hash/n-merge-bang-vs-[]=.rb
+++ b/code/hash/n-merge-bang-vs-[]=.rb
@@ -1,0 +1,22 @@
+require 'benchmark/ips'
+
+ENUM = (1..100)
+HASH = ENUM.to_h{ |a| [a, a]}
+SECOND_HASH = ENUM.to_h{ |a| [a+50, a+50]}
+
+def merge
+  h = HASH
+  h.merge!(SECOND_HASH)
+end
+
+def assign
+  ENUM.each_with_object({}) do |e, h|
+    h[e] = e
+  end
+end
+
+Benchmark.ips do |x|
+  x.report('Hash#merge!') { merge }
+  x.report('Hash#[]=') { assign }
+  x.compare!
+end


### PR DESCRIPTION
The [code/hash/merge-bang-vs-[]=.rb](https://github.com/JuanitoFatas/fast-ruby/blob/38f49f95fc7574d929de60b71791d09129c2588c/code/hash/merge-bang-vs-%5B%5D=.rb) benchmark merges N 1-element hashes to compare it with N hash element assignments using `[]=`. Obviously assignments are faster, but this is not a real-life scenario.

The more common case would be to perform one merge an N-element hash and it appears it is much faster to do it than to perform N assignments. This PR implements such a benchmark.