### PR TITLE
String#constantize vs simple comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module_eval with string:     1129.7 i/s - 1.19x slower
 
 ##### `String#constantize` vs a comparison for inflection
 
-ActiveSupport's [String#constantize](https://doc.bccnsoft.com/docs/rails-guides-4.2.1-en/active_support_core_extensions.html#constantize) "resolves the constant reference expression in its receiver".
+ActiveSupport's [String#constantize](https://guides.rubyonrails.org/active_support_core_extensions.html#constantize) "resolves the constant reference expression in its receiver".
 
 [Read the rationale here](https://github.com/fastruby/fast-ruby/pull/200)
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module_eval with string:     1129.7 i/s - 1.19x slower
 
 ActiveSupport's [String#constantize](https://doc.bccnsoft.com/docs/rails-guides-4.2.1-en/active_support_core_extensions.html#constantize) "resolves the constant reference expression in its receiver".
 
-[Read the rationale here](asdf)
+[Read the rationale here](https://github.com/fastruby/fast-ruby/pull/200)
 
 ```
 ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-darwin20]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ Comparison:
 module_eval with string:     1129.7 i/s - 1.19x slower
 ```
 
+##### `String#constantize` vs a comparison for inflection
+
+ActiveSupport's [String#constantize](https://doc.bccnsoft.com/docs/rails-guides-4.2.1-en/active_support_core_extensions.html#constantize) "resolves the constant reference expression in its receiver".
+
+[Read the rationale here](asdf)
+
+```
+ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-darwin20]
+
+Calculating -------------------------------------
+        using a Hash      8.641M (± 1.9%) i/s -     43.818M in   5.073094s
+using a case statement
+                          8.314M (± 3.1%) i/s -     41.587M in   5.007488s
+using an if statement
+                          8.295M (± 3.3%) i/s -     41.524M in   5.012041s
+  String#constantize      2.365M (± 3.7%) i/s -     11.884M in   5.032603s
+
+Comparison:
+        using a Hash:  8640697.2 i/s
+using a case statement:  8313545.9 i/s - same-ish: difference falls within error
+using an if statement:  8295324.8 i/s - same-ish: difference falls within error
+  String#constantize:  2365366.0 i/s - 3.65x  (± 0.00) slower
+```
+
 ##### `raise` vs `E2MM#Raise` for raising (and defining) exeptions  [code](code/general/raise-vs-e2mmap.rb)
 
 Ruby's [Exception2MessageMapper module](http://ruby-doc.org/stdlib-2.2.0/libdoc/e2mmap/rdoc/index.html) allows one to define and raise exceptions with predefined messages.

--- a/README.md
+++ b/README.md
@@ -143,18 +143,13 @@ ActiveSupport's [String#constantize](https://doc.bccnsoft.com/docs/rails-guides-
 ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-darwin20]
 
 Calculating -------------------------------------
-        using a Hash      8.641M (± 1.9%) i/s -     43.818M in   5.073094s
-using a case statement
-                          8.314M (± 3.1%) i/s -     41.587M in   5.007488s
 using an if statement
-                          8.295M (± 3.3%) i/s -     41.524M in   5.012041s
-  String#constantize      2.365M (± 3.7%) i/s -     11.884M in   5.032603s
+                          8.124M (± 1.8%) i/s -     41.357M in   5.092437s
+  String#constantize      2.462M (± 2.4%) i/s -     12.315M in   5.004089s
 
 Comparison:
-        using a Hash:  8640697.2 i/s
-using a case statement:  8313545.9 i/s - same-ish: difference falls within error
-using an if statement:  8295324.8 i/s - same-ish: difference falls within error
-  String#constantize:  2365366.0 i/s - 3.65x  (± 0.00) slower
+using an if statement:  8123851.3 i/s
+  String#constantize:  2462371.2 i/s - 3.30x  (± 0.00) slower
 ```
 
 ##### `raise` vs `E2MM#Raise` for raising (and defining) exeptions  [code](code/general/raise-vs-e2mmap.rb)

--- a/code/general/constantize-vs-comparison.rb
+++ b/code/general/constantize-vs-comparison.rb
@@ -3,19 +3,6 @@ require "benchmark/ips"
 
 class Foo; end
 
-def fast3(s, h)
-  klass = h[s]
-  nil
-end
-
-def fast2(s)
-  klass = case s
-  when "Foo"
-    Foo
-  end
-  nil
-end
-
 def fast(s)
   klass = Foo if s == "Foo"
   nil
@@ -27,10 +14,6 @@ def slow(s)
 end
 
 Benchmark.ips do |x|
-  h = { "Foo" => Foo }
-
-  x.report("using a Hash") { fast3("Foo", h) }
-  x.report("using a case statement") { fast2("Foo") }
   x.report("using an if statement") { fast("Foo") }
   x.report("String#constantize") { slow("Foo") }
   x.compare!

--- a/code/general/constantize-vs-comparison.rb
+++ b/code/general/constantize-vs-comparison.rb
@@ -1,0 +1,37 @@
+require "active_support/core_ext/string/inflections.rb"
+require "benchmark/ips"
+
+class Foo; end
+
+def fast3(s, h)
+  klass = h[s]
+  nil
+end
+
+def fast2(s)
+  klass = case s
+  when "Foo"
+    Foo
+  end
+  nil
+end
+
+def fast(s)
+  klass = Foo if s == "Foo"
+  nil
+end
+
+def slow(s)
+  klass = s.constantize
+  nil
+end
+
+Benchmark.ips do |x|
+  h = { "Foo" => Foo }
+
+  x.report("using a Hash") { fast3("Foo", h) }
+  x.report("using a case statement") { fast2("Foo") }
+  x.report("using an if statement") { fast("Foo") }
+  x.report("String#constantize") { slow("Foo") }
+  x.compare!
+end


### PR DESCRIPTION
If you're writing a Rails app, you may reach for `String#constantize` (provided by [Active Support Core Extensions](https://guides.rubyonrails.org/active_support_core_extensions.html#constantize)) when you have a variable that may resolve to a class name and your control flow is to execute that classes code in some manner.

This benchmarks using `String#constantize` vs a simple comparison, showing the latter is much faster.