### PR TITLE
Set the SHARE env variable only if current branch is main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,7 +10,7 @@ jobs:
   rake:
     runs-on: ubuntu-latest
     env:
-      SHARE: "1"
+      SHARE: ${{ github.ref_name == 'main' && '1' || '' }}
 
     strategy:
       matrix:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   rake:
     runs-on: ubuntu-latest
-    env:
-      SHARE: ${{ github.ref_name == 'main' && '1' || '' }}
 
     strategy:
       matrix:
@@ -19,6 +17,10 @@ jobs:
                        'jruby-head']
 
     steps:
+      - name: Set Share Env
+        if: github.ref_name == 'main'
+        run: |
+          echo "SHARE=1" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR changes the setup of the workflow to only set the `SHARE` env variable if the current branch is main.

I have no way of testing this completely until is merged into main.

I first tried to set either `1` or an empty string to the SHARE variable but it didn't work (bechmarks.ips only checks if the env variable is set, not the value, so an empty var triggers the sharing too).

Instead, I went with the solution from the docs here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files, making the step that sets the env variable conditional to the branch name.

Fixes https://github.com/fastruby/fast-ruby/issues/207