### PR TITLE
Run benchmarks on TruffleRuby in CI.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ruby-version: ['3.1', '3.0', '2.7', '2.5.1',  '2.4.3',  '2.3.0',
                        '2.1.9',  '2.2.10', 'ruby-head', 'jruby-9.1.17.0',
-                       'jruby-head']
+                       'jruby-head', 'truffleruby-22.3.0', 'truffleruby-head']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
TruffleRuby is a high speed implementation of Ruby. It should run all of these benchmarks just fine. I think it'd be interesting to see the results. I suspect in many cases, the JIT can optimize the different variants of a given benchmark so that there is no clear winner. In cases where it does not, that indicates an opportunity for the JIT to improve.