### PR TITLE
Change benchmark template to be more impartial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Use [benchmark-ips](https://github.com/evanphx/benchmark-ips) (2.0+).
 ```ruby
 require "benchmark/ips"
 
-def fast
+def a
 end
 
-def slow
+def b
 end
 
 Benchmark.ips do |x|


### PR DESCRIPTION
By defining methods `fast` and `slow`, we lock the benchmark into whatever the results were on a particular Ruby at a particular time. Since the benchmarks are run on multiple versions of Ruby and on multiple Ruby interpreters, which variant is faster is subject to change.

I don't love the names "a" and "b", so I'm very much open to alternative naming conventions, so long as the method name either describes the variant being benchmarks or has an impartial name that just indicates it's another variant.