### PR TITLE
Fix 217: Add activesupport and e2mmap to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source 'https://rubygems.org'
 
 gem 'benchmark-ips', '>= 2.0'
 
+gem 'activesupport', '>= 2.2.1'
+gem 'e2mmap'
+
 gem 'rake'


### PR DESCRIPTION
Fixes #217

### before
```
➜  fast-ruby git:(main) bundle exec ruby code/general/constantize-vs-comparison.rb
code/general/constantize-vs-comparison.rb:1:in `require': cannot load such file -- active_support/core_ext/string/inflections.rb (LoadError)
	from code/general/constantize-vs-comparison.rb:1:in `<main>'
➜  fast-ruby git:(main) bundle exec ruby code/general/raise-vs-e2mmap.rb
code/general/raise-vs-e2mmap.rb:2:in `require': cannot load such file -- e2mmap (LoadError)
	from code/general/raise-vs-e2mmap.rb:2:in `<main>'
```

### after
```
➜  fast-ruby git:(fix_217_add_e2mmap_and_activesupport_to_gemfile) ✗ bundle exec ruby code/general/constantize-vs-comparison.rb
Warming up --------------------------------------
using an if statement
                       697.251k i/100ms
  String#constantize   418.324k i/100ms
Calculating -------------------------------------
using an if statement
                          6.931M (± 2.2%) i/s -     34.863M in   5.032747s
  String#constantize      4.193M (± 0.6%) i/s -     21.335M in   5.087847s

Comparison:
using an if statement:  6930852.6 i/s
  String#constantize:  4193411.5 i/s - 1.65x  (± 0.00) slower

➜  fast-ruby git:(fix_217_add_e2mmap_and_activesupport_to_gemfile) ✗ bundle exec ruby code/general/raise-vs-e2mmap.rb
Warming up --------------------------------------
Ruby exception: E2MM#Raise
                         6.104k i/100ms
Ruby exception: Kernel#raise
                       139.803k i/100ms
Calculating -------------------------------------
Ruby exception: E2MM#Raise
                         60.721k (± 2.4%) i/s -    305.200k in   5.029147s
Ruby exception: Kernel#raise
                          1.482M (± 4.3%) i/s -      7.410M in   5.010997s

Comparison:
Ruby exception: Kernel#raise:  1481602.5 i/s
Ruby exception: E2MM#Raise:    60720.7 i/s - 24.40x  (± 0.00) slower

Warming up --------------------------------------
Custom exception: E2MM#Raise
                         6.146k i/100ms
Custom exception: Kernel#raise
                       149.385k i/100ms
Calculating -------------------------------------
Custom exception: E2MM#Raise
                         60.551k (± 2.9%) i/s -    307.300k in   5.079461s
Custom exception: Kernel#raise
                          1.462M (± 5.4%) i/s -      7.320M in   5.022675s

Comparison:
Custom exception: Kernel#raise:  1462002.3 i/s
Custom exception: E2MM#Raise:    60550.9 i/s - 24.15x  (± 0.00) slower
```