### PR TITLE
Run old rubies with Ubuntu 20 in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,9 +12,31 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7', '2.5.1',  '2.4.3',  '2.3.0',
-                       '2.1.9',  '2.2.10', 'ruby-head', 'jruby-9.1.17.0',
-                       'jruby-head', 'truffleruby-22.3.0', 'truffleruby-head']
+        ruby-version: ['3.1', '3.0', '2.7', '2.5.1',  '2.4.3', 'ruby-head',
+                       'jruby-9.1.17.0', 'jruby-head', 'truffleruby-22.3.0',
+                       'truffleruby-head']
+
+    steps:
+      - name: Set Share Env
+        if: github.ref_name == 'main'
+        run: |
+          echo "SHARE=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run benchmarks
+        run: bundle exec rake
+
+  rake:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        ruby-version: ['2.3.0', '2.1.9',  '2.2.10']
 
     steps:
       - name: Set Share Env

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Run benchmarks
         run: bundle exec rake
 
-  rake:
+  rake_old:
     runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        ruby-version: ['2.3.0', '2.1.9',  '2.2.10']
+        ruby-version: ['2.3.0', '2.1.9', '2.2.10']
 
     steps:
       - name: Set Share Env


### PR DESCRIPTION
This PR fixes issues when running old Ruby versions in CI using `ubuntu-latest`.

The sig fault error seems to be a known issue https://github.com/ruby/setup-ruby/issues/496#issuecomment-1520667671

The workaround is to use ubuntu 20.04 for older rubies instead of ubuntu-latest.

(CI was running fine, it was cancelled to avoid flooding ips.fastruby.io with benchmarks)